### PR TITLE
Remove .exe so PowerShell Core works on Linux (and in n8n Docker)

### DIFF
--- a/nodes/PowerShell/PowerShell.node.ts
+++ b/nodes/PowerShell/PowerShell.node.ts
@@ -74,7 +74,7 @@ export class PowerShell implements INodeType {
 					},
 					{
 						name: 'PowerShell Core',
-						value: 'pwsh.exe',
+						value: 'pwsh',
 					},
 				],
 			},


### PR DESCRIPTION
Remove .exe so PowerShell Core works on Linux (and in n8n Docker). Windows do not care about the missing .exe as it does not by default have any file like .cmd that would be called first.

Tips: If you want to test it without building you own docker image from docker.n8n.io/n8nio/n8n, exec into the running docker and install PowerShell -
```bash

# Install PowerShell (remember you have to build your own docker as this is only temporary)
apk add powershell
```
To make this custom node work before this is being merged -

```bash
# Create a .exe path
ln -s /usr/bin/pwsh /usr/bin/pwsh.exe
```